### PR TITLE
fix: assert not snowpark_utils.is_in_stored_procedure() fails

### DIFF
--- a/3_sf_nb_snowflake_ml_model_training_inference.ipynb
+++ b/3_sf_nb_snowflake_ml_model_training_inference.ipynb
@@ -1045,6 +1045,7 @@
     "    model_name=model_name,\n",
     "    version_name='V1',\n",
     "    model=optimal_model,\n",
+    "    options={\"embed_local_ml_library\": True},\n",
     "    sample_input_data=X, # to provide the feature schema\n",
     ")\n",
     "\n",


### PR DESCRIPTION
Current version of the ml registry needs the extra parameter, otherwise this step fails with:

File "<..>/env_utils.py", line 371, in get_matched_package_versions_in_snowflake_conda_channel
    assert not snowpark_utils.is_in_stored_procedure()  # type: ignore[no-untyped-call]

Upcoming release should fix this:

https://docs.snowflake.com/developer-guide/snowpark-ml/model-registry/overview#current-limitations-and-issues

For now, the parameter is needed.